### PR TITLE
Fix(build): Build Linux release on ubuntu-20.04 for GLIBC compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
       matrix:
         include:
           # Temporarily disable Linux and Windows to focus on macOS
-          # - os: ubuntu-latest
-          #   lld_name: ld.lld
-          #   artifact_name: x86_64-unknown-linux-gnu
+          - os: ubuntu-20.04
+            lld_name: ld.lld
+            artifact_name: x86_64-unknown-linux-gnu
           - os: macos-latest
             lld_name: ld.lld
             artifact_name: aarch64-apple-darwin


### PR DESCRIPTION
The previous Linux release binaries were built using `ubuntu-latest` in GitHub Actions. This resulted in the `bam` executable being linked against a newer version of GLIBC than available on many common Linux distributions, leading to errors like: `./bam: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.39' not found`

This change modifies the release workflow (`.github/workflows/release.yml`) to use `ubuntu-20.04` for the x86_64 Linux builds. Ubuntu 20.04 (Focal Fossa) uses GLIBC 2.31, which is significantly older and more widely compatible.

This will ensure the `bam` binary can run on a broader range of Linux systems, including those with older GLIBC versions, without requiring you to have the very latest distributions.