### PR TITLE
Feat(build): Build statically linked Linux releases with musl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
       matrix:
         include:
           # Temporarily disable Linux and Windows to focus on macOS
-          # - os: ubuntu-latest
-          #   lld_name: ld.lld
-          #   artifact_name: x86_64-unknown-linux-gnu
+          - os: ubuntu-20.04
+            lld_name: ld.lld
+            artifact_name: x86_64-unknown-linux-musl
           - os: macos-latest
             lld_name: ld.lld
             artifact_name: aarch64-apple-darwin
@@ -144,7 +144,15 @@ jobs:
       - name: Run tests
         run: cargo test
 
+      - name: Install musl target for Rust
+        if: matrix.os == 'ubuntu-20.04'
+        run: rustup target add x86_64-unknown-linux-musl
+
       - name: Build bam
+        if: matrix.os == 'ubuntu-20.04'
+        run: cargo build --release --target x86_64-unknown-linux-musl
+      - name: Build bam
+        if: matrix.os != 'ubuntu-20.04'
         run: cargo build --release
 
       - name: Extract rust-lld for bundling
@@ -171,6 +179,8 @@ jobs:
             # Copy bam executable  
             if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
               cp "target/release/bam.exe" "package/"
+            elif [[ "${{ matrix.os }}" == "ubuntu-20.04" ]]; then
+              cp "target/x86_64-unknown-linux-musl/release/bam" "package/"
             else
               cp "target/release/bam" "package/"
             fi
@@ -296,7 +306,7 @@ jobs:
             ### Installation
             
             1. Download the appropriate package for your platform:
-               - **Linux**: `bam-${{ steps.release_details.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz`
+               - **Linux**: `bam-${{ steps.release_details.outputs.version }}-x86_64-unknown-linux-musl.tar.gz`
                - **macOS**: `bam-${{ steps.release_details.outputs.version }}-x86_64-apple-darwin.tar.gz`  
                - **Windows**: `bam-${{ steps.release_details.outputs.version }}-x86_64-pc-windows-msvc.zip`
             
@@ -382,8 +392,8 @@ jobs:
           
           # Upload Linux package
           upload_asset \
-            "./artifacts/release-x86_64-unknown-linux-gnu-${VERSION}/bam-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
-            "bam-${VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            "./artifacts/release-x86_64-unknown-linux-musl-${VERSION}/bam-${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            "bam-${VERSION}-x86_64-unknown-linux-musl.tar.gz" \
             "application/gzip"
           
           # Upload macOS package


### PR DESCRIPTION
Previously, Linux binaries were dynamically linked against GLIBC, leading to compatibility issues on systems with older GLIBC versions. Specifically, errors like `./bam: /lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.39' not found` were reported even when building on ubuntu-20.04.

This change modifies the GitHub Actions release workflow (`.github/workflows/release.yml`) for the Linux build (x86_64) to target `x86_64-unknown-linux-musl`. This produces a statically linked `bam` executable, minimizing dependencies on the target system's libc version and ensuring much broader compatibility across various Linux distributions.

The changes include:
- Adding the `x86_64-unknown-linux-musl` rustup target.
- Updating the cargo build command to use `--target x86_64-unknown-linux-musl`.
- Adjusting paths and artifact names for the new target.
- Updating release notes template and asset upload logic to reflect the new artifact name (`x86_64-unknown-linux-musl`).