### PR TITLE
Fix(build): Explicitly set +crt-static for Linux musl builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,8 @@ jobs:
 
       - name: Build bam
         if: matrix.os == 'ubuntu-20.04'
+        env:
+          RUSTFLAGS: "-C target-feature=+crt-static"
         run: cargo build --release --target x86_64-unknown-linux-musl
       - name: Build bam
         if: matrix.os != 'ubuntu-20.04'


### PR DESCRIPTION
Despite targeting x86_64-unknown-linux-musl, previous builds still resulted in dynamically GLIBC-linked binaries. This change adds `RUSTFLAGS="-C target-feature=+crt-static"` to the Linux musl build step in the GitHub Actions workflow.

While +crt-static is typically implied by the musl target, this explicit setting aims to override any potential misconfiguration or obscure default behavior in the toolchain or dependencies that might be preventing a fully static build. This is a further attempt to ensure the Linux release binary is truly portable and does not link against GLIBC.