### PR TITLE
FIX: Ensure Install Rust target step uses bash on Windows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -87,6 +87,7 @@ jobs:
       - name: Install Rust target
         # Always run rustup target add, it's idempotent and quick if already installed.
         # Handles cases where matrix.target might be empty if we forget to add one.
+        shell: bash # Ensure this runs in bash for all OSs, especially Windows
         run: |
           if [[ -n "${{ matrix.target }}" ]]; then
             rustup target add ${{ matrix.target }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,7 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Install Rust target
+        shell: bash # Ensure this runs in bash for all OSs, especially Windows
         run: |
           if [[ -n "${{ matrix.target }}" ]]; then
             rustup target add ${{ matrix.target }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,7 @@ jobs:
         run: cargo test
 
       - name: Install Rust target
+        shell: bash # Ensure this runs in bash for all OSs, especially Windows
         run: |
           if [[ -n "${{ matrix.target }}" ]]; then
             rustup target add ${{ matrix.target }}


### PR DESCRIPTION
Added `shell: bash` to the `Install Rust target` step in all three workflow files (beta.yml, pr.yml, release.yml).

This fixes an error on Windows runners where the bash `if [[ ... ]]` syntax would cause a PowerShell parser error because PowerShell is the default shell on Windows runners if not otherwise specified.