### PR TITLE
FIX: Ensure Build bam step uses bash on Windows

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -96,6 +96,7 @@ jobs:
           fi
 
       - name: Build bam
+        shell: bash # Ensure this runs in bash for all OSs, especially Windows
         env:
           RUSTFLAGS: ${{ (matrix.target == 'x86_64-unknown-linux-musl' && '-C target-feature=+crt-static') || '' }}
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,6 +92,7 @@ jobs:
           fi
 
       - name: Build bam
+        shell: bash # Ensure this runs in bash for all OSs, especially Windows
         env:
           RUSTFLAGS: ${{ (matrix.target == 'x86_64-unknown-linux-musl' && '-C target-feature=+crt-static') || '' }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,7 @@ jobs:
           fi
 
       - name: Build bam
+        shell: bash # Ensure this runs in bash for all OSs, especially Windows
         env:
           RUSTFLAGS: ${{ (matrix.target == 'x86_64-unknown-linux-musl' && '-C target-feature=+crt-static') || '' }}
         run: |


### PR DESCRIPTION
Added `shell: bash` to the `Build bam` step in all three workflow files (beta.yml, pr.yml, release.yml).

This mirrors the previous fix for the `Install Rust target` step and ensures that bash conditionals run correctly on Windows runners.